### PR TITLE
Fix #1, Update to use rtems-4.11 in rtems4.11 Dockerfile

### DIFF
--- a/rtems-4.11/Dockerfile
+++ b/rtems-4.11/Dockerfile
@@ -12,23 +12,23 @@ run apt-get install -y qemu-system-i386
 
 
 # setup and compile RTEMS BSP
-run mkdir -p ${HOME}/rtems-5 \
+run mkdir -p ${HOME}/rtems-4.11 \
   && cd ${HOME} \
-  && git clone -b 5 git://git.rtems.org/rtems-source-builder.git \
+  && git clone -b 4.11 git://git.rtems.org/rtems-source-builder.git \
   && cd rtems-source-builder/rtems \
-  && ../source-builder/sb-set-builder --prefix=$HOME/rtems-5 5/rtems-i386 \
+  && ../source-builder/sb-set-builder --prefix=$HOME/rtems-4.11 4.11/rtems-i386 \
 # clone and bootstrap RTEMS source tree
   && cd ${HOME} \
-  && git clone -b 5 git://git.rtems.org/rtems.git \
-  && export PATH=$HOME/rtems-5/bin:$PATH \
+  && git clone -b 4.11 git://git.rtems.org/rtems.git \
+  && export PATH=$HOME/rtems-4.11/bin:$PATH \
   && cd rtems && ./bootstrap \
 # Build and install RTEMS pc686 BSP
   && cd ${HOME} \
   && mkdir b-pc686 \
   && cd b-pc686 \
-  && ../rtems/configure --target=i386-rtems5 \
+  && ../rtems/configure --target=i386-rtems4.11 \
     --enable-rtemsbsp=pc686 \
-    --prefix=${HOME}/rtems-5 \
+    --prefix=${HOME}/rtems-4.11 \
     --enable-networking \
     --enable-cxx \
     --disable-posix \


### PR DESCRIPTION
Fixes #1 

Replace the mentioning of rtems5 with rtems-4.11. 

Needs to be used in Docker Build & Push Action.