### PR TITLE
Fix #7, Add BSP Configuration for RTEMS 4.11

### DIFF
--- a/rtems-4.11/Dockerfile
+++ b/rtems-4.11/Dockerfile
@@ -37,6 +37,11 @@ run mkdir -p ${HOME}/rtems-4.11 \
     --enable-cxx \
     --disable-posix \
     --disable-deprecated \
+    BSP_ENABLE_VGA=0 \
+    CLOCK_DRIVER_USE_TSC=1 \
+    USE_COM1_AS_CONSOLE=1 \
+    BSP_PRESS_KEY_FOR_RESET=0 \
+    BSP_RESET_BOARD_AT_EXIT=1 \
   && make \
   && make install
 


### PR DESCRIPTION
Fixes #7 

Tested on fork: https://github.com/ArielSAdamsNASA/cFS-JSF-Rules/runs/4388525329?check_suite_focus=true

Tests no longer stuck at 
```
Formatting 'build/exe/cpu1/coverage-es-ALL-testrunner.cow', fmt=qcow2 size=33554432 backing_file=nonvol-disk.img backing_fmt=raw cluster_size=65536 lazy_refcounts=off refcount_bits=16
qemu-system-i386 -m 128 -no-reboot -display none \
    -kernel build/exe/cpu1/coverage-es-ALL-testrunner.exe \
    -append '--batch-mode --console=/dev/com1' \
    -drive file=build/exe/cpu1/coverage-es-ALL-testrunner.cow,format=qcow2 \
    -device i82557b,netdev=net0,mac=00:04:9F:9B:5C:1D \
    -netdev user,id=net0 \
    -serial file:build/exe/cpu1/coverage-es-ALL-testrunner.log.tmp
```

BSP_ENABLE_VGA
Enables VGA console driver (enabled by default).

CLOCK_DRIVER_USE_TSC
Enforces clock driver to use TSC register available on Pentium and higher class CPUs. If disabled and CLOCK_DRIVER_USE_8243 is disabled too, then BSP will choose clock driver mechanism itself during the runtime (disabled by default).

USE_COM1_AS_CONSOLE
Enforces usage of COM1 as a console device (disabled by default).

BSP_PRESS_KEY_FOR_RESET
If defined to a non-zero value, then print a message and wait until any key is pressed before resetting board when application terminates (disabled by default).

BSP_RESET_BOARD_AT_EXIT
If defined to a non-zero value, then reset the board when the application terminates (enabled by default).

https://docs.rtems.org/branches/master/user/bsps/bsps-i386.html#pc386