### PR TITLE
Fix #13, Adds 20.04 Ubuntu

### DIFF
--- a/rtems-4.11/Dockerfile
+++ b/rtems-4.11/Dockerfile
@@ -1,4 +1,5 @@
-from ubuntu:18.04
+from ubuntu:20.04
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Basic dependencies
 run apt-get update && apt-get install -y git make curl

--- a/rtems-5/Dockerfile
+++ b/rtems-5/Dockerfile
@@ -1,4 +1,5 @@
-from ubuntu:18.04
+from ubuntu:20.04
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Basic dependencies
 run apt-get update && apt-get install -y git make

--- a/rtems-6/Dockerfile
+++ b/rtems-6/Dockerfile
@@ -1,10 +1,14 @@
-from ubuntu:18.04
+from ubuntu:20.04
+ENV DEBIAN_FRONTEND=noninteractive
 
 # Basic dependencies
 run apt-get update && apt-get install -y git make
 
 # rtems dependencies
 run apt-get install -y flex bison texinfo python-dev g++ unzip
+
+# Added: Python development package installation for RTEMS build dependencies
+run apt-get install -y python3-dev libpython3-dev
 
 # QEMU dependencies
 run apt-get install -y qemu-system-i386


### PR DESCRIPTION
* Fixes #13, Adds node.js 20 support to the dockerfiles

The Node.js 20 runtime environment mandates the GNU C Library (glibc) version 2.28 or later. This version of the GNU C library is compatible only with Ubuntu 20.04 and later versions. Therefore, it is necessary to upgrade from Ubuntu 18.04 to ensure compatibility.