### PR TITLE
Fix #14, Modified MC/DC Dockerfile to install jq

### DIFF
--- a/mcdc/Dockerfile
+++ b/mcdc/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get update && apt-get install -y \
     cmake \
     lcov \
     python3 \
+    jq \
     && rm -rf /var/lib/apt/lists/*
 
 # Configure dynamic linker to include /usr/local/lib (for GCC libraries)


### PR DESCRIPTION
Modified MC/DC Dockerfile to install jq so that the MC/DC workflow can use the jq tool