### PR TITLE
Fix #27, Use Latest Tag on Main

### DIFF
--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -31,18 +31,27 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Determine Docker Tag
+        id: determine_tag
+        run: |
+          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
+            echo "DOCKER_TAG=latest" >> $GITHUB_ENV
+            echo "Building with tag: latest (Main branch)"
+          else
+            echo "DOCKER_TAG=ci" >> $GITHUB_ENV
+            echo "Building with tag: ci (Non-main branch/PR)"
+          fi
+
       - name: Build All Images
         run: |
           make \
             TGT_REPO=ghcr.io/${{ github.repository_owner }} \
-            REPO_TAG=latest \
-            LOCAL_TAG=ci \
+            LOCAL_TAG=${{ env.DOCKER_TAG }} \
             all
 
       - name: Push All Images
         run: |
           make \
             TGT_REPO=ghcr.io/${{ github.repository_owner }} \
-            REPO_TAG=latest \
-            LOCAL_TAG=ci \
+            LOCAL_TAG=${{ env.DOCKER_TAG }} \
             push


### PR DESCRIPTION
Fixes #27 

Updates the workflow building and pushing the containers to use the `latest` tag if the workflow is ran on the main branch. Otherwise it should use the `ci` tag. 