### PR TITLE
Fix #29, Add clang-format-19

### DIFF
--- a/cfsbuildenv-dpkg/Dockerfile
+++ b/cfsbuildenv-dpkg/Dockerfile
@@ -10,11 +10,18 @@ ARG BASE_IMAGE=debian:latest
 FROM ${BASE_IMAGE} AS cfsbuildenv-dpkg
 
 ARG EXTRA_PKGS=""
+ARG CLANG_VERSION=19
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
-        sudo ca-certificates curl lsb-release software-properties-common \
+        sudo ca-certificates curl lsb-release software-properties-common gnupg \
         build-essential git gcc g++ gawk cmake lcov xsltproc rsync jq file \
         python3 python3-venv python3-dev python3-pip openssh-client \
-        libexpat-dev liblua5.3-dev libjson-c-dev xz-utils cppcheck clang-format wget \
+        libexpat-dev liblua5.3-dev libjson-c-dev xz-utils cppcheck wget \
         ${EXTRA_PKGS} && \
+    rm -rf /var/cache/apt
+
+RUN curl -fsL https://apt.llvm.org/llvm.sh >> /root/llvm.sh && bash /root/llvm.sh ${CLANG_VERSION}
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
+	clang-${CLANG_VERSION} clang-format-${CLANG_VERSION} clang-tools-${CLANG_VERSION} clang-tidy-${CLANG_VERSION} && \
     rm -rf /var/cache/apt


### PR DESCRIPTION
Fixes #29 

Built and pushed these container changes [here](https://github.com/arielswalker/containers/actions/runs/25127054897). Ensured that [Format Check workflow](https://github.com/arielswalker/cFS/actions/runs/25133492499/job/73665682004?pr=8#step:6:1) can now use clang-format-19 by calling these pushed containers. Format check is failing with other errors related to SBN and a bad commit message. 