### PR TITLE
Fix #24, update yocto recipes

### DIFF
--- a/.github/actions/build-image/action.yml
+++ b/.github/actions/build-image/action.yml
@@ -1,0 +1,41 @@
+name: 'Build and Push docker image'
+description: 'Builds the docker image and pushes it to the container repo'
+
+inputs:
+  target-image:
+    description: Image Target name
+    type: string
+    required: true
+  registry-token:
+    description: Token for logging into container registry
+    type: string
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v4
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ inputs.registry-token }}
+
+    # This step is intended to improve build speeds -- if the image is not changed
+    # from latest then docker may figure this out and not rebuild it
+    - name: Pull from Latest
+      shell: bash
+      run: make REPO_TAG=latest ${{ inputs.target-image }}.pull || /bin/true
+
+    - name: Build Image
+      shell: bash
+      run: make ${{ inputs.target-image }}.image
+
+    - name: Push Image
+      shell: bash
+      run: make ${{ inputs.target-image }}.push
+
+    - name: Push as Latest
+      if: github.ref == github.event.repository.default_branch
+      shell: bash
+      run: make REPO_TAG=latest ${{ inputs.target-image }}.push

--- a/.github/workflows/registry.yml
+++ b/.github/workflows/registry.yml
@@ -6,52 +6,59 @@ on:
     branches:
       - main
 
+env:
+  TGT_REPO: ghcr.io/${{ github.repository_owner }}
+
 jobs:
-  build-and-push:
-    name: Build and Push Docker Images
+  build-sdk:
+    name: Build SDK Images
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target-image: [ arm-linux-sdk, gaisler-sparc-rcc-sdk, rtems5-tools, rtems6-tools ]
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Verify repo structure
-        run: |
-          echo "=== Repo root ==="
-          ls -la
-          echo "=== Dockerfile locations ==="
-          find . -name "Dockerfile" | sort
-          echo "=== docker-executor contents ==="
-          ls -la docker-executor/
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v4
+      - name: Build and push image
+        uses: ./.github/actions/build-image
         with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          target-image: ${{ matrix.target-image }}
+          registry-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Determine Docker Tag
-        id: determine_tag
-        run: |
-          if [ "${{ github.ref }}" = "refs/heads/main" ]; then
-            echo "DOCKER_TAG=latest" >> $GITHUB_ENV
-            echo "Building with tag: latest (Main branch)"
-          else
-            echo "DOCKER_TAG=ci" >> $GITHUB_ENV
-            echo "Building with tag: ci (Non-main branch/PR)"
-          fi
+  build-basic:
+    name: Build System/OS Images
+    needs: build-sdk
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target-image: [ cfsexec-qemu, cfsexec-linux, cfsexec-ubuntu22, rtems5-rtos, rtems6-rtos ]
 
-      - name: Build All Images
-        run: |
-          make \
-            TGT_REPO=ghcr.io/${{ github.repository_owner }} \
-            LOCAL_TAG=${{ env.DOCKER_TAG }} \
-            all
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
 
-      - name: Push All Images
-        run: |
-          make \
-            TGT_REPO=ghcr.io/${{ github.repository_owner }} \
-            LOCAL_TAG=${{ env.DOCKER_TAG }} \
-            push
+      - name: Build and push image
+        uses: ./.github/actions/build-image
+        with:
+          target-image: ${{ matrix.target-image }}
+          registry-token: ${{ secrets.GITHUB_TOKEN }}
+
+  build-buildenv:
+    name: CFS Build Environment Images
+    needs: build-basic
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target-image: [ cfsbuildenv-doxygen, cfsbuildenv-linux, cfsbuildenv-mcdc, cfsbuildenv-rtems5, cfsbuildenv-rtems6, cfsbuildenv-arm-linux, cfsbuildenv-ubuntu22, cfsbuildenv-el9, cfsbuildenv-el8, cfsbuildenv-gaisler-sparc-rcc, cfsbuildenv-yocto ]
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Build and push image
+        uses: ./.github/actions/build-image
+        with:
+          target-image: ${{ matrix.target-image }}
+          registry-token: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -2,27 +2,32 @@
 # This is useful when debugging, so as to not REQUIRE the use of CI/CD to build
 
 LOCAL_TAG ?= $(shell git rev-parse --short HEAD)
-TGT_REPO ?= ghcr.io/core-flight-system/containers
-REPO_TAG ?= latest
+TGT_REPO ?= ghcr.io/core-flight-system
+REPO_TAG ?= $(LOCAL_TAG)
+
+PULL_DEP_CMD = docker inspect  --format '{{.Id}}' $(QUALIFIED_LOCAL_NAME)
+MAKE_DEP_CMD = $(MAKE) $(IMAGE_NAME).build
 
 # If AUTOBUILD_DEPS is set, then recursively build any missing images
 # that are dependencies of the target image.  If this is not set,
 # then the build will fail if the dependency does not exist.  This
 # must always be true at the top level or else nothing will build.
 ifeq ($(MAKELEVEL),0)
-AUTOBUILD_DEPS ?= 1
-endif
-
-ifneq ($(AUTOBUILD_DEPS),)
-BUILD_DEP_CMD = $(MAKE) $(IMAGE_NAME).build
+# On the first level make we must build it if it is part of MAKECMDGOALS, never fetch it
+BUILD_DEP_CMD = if [ "x$(findstring $(@),$(MAKECMDGOALS))" = "x" ]; then $(PULL_DEP_CMD); else $(MAKE_DEP_CMD); fi 
+else ifneq ($(AUTOBUILD_DEPS),)
+# On other levels, fetch if exists, otherwise build it
+BUILD_DEP_CMD = $(PULL_DEP_CMD) || $(MAKE_DEP_CMD)
 else
-BUILD_DEP_CMD = /bin/false
+# Never build the image, only fetch it
+BUILD_DEP_CMD = $(PULL_DEP_CMD)
 endif
 
 # The option --no-cache can be specified on command line if desired
 EXTRA_BUILDARGS += --progress=plain
 
-QUALIFIED_IMAGE_NAME = $(IMAGE_NAME):$(LOCAL_TAG)
+QUALIFIED_LOCAL_NAME = $(TGT_REPO)/$(IMAGE_NAME):$(LOCAL_TAG)
+QUALIFIED_REPO_NAME  = $(TGT_REPO)/$(IMAGE_NAME):$(REPO_TAG)
 
 BASIC_IMAGE_SET += docker-executor
 BASIC_IMAGE_SET += cfsexec-qemu
@@ -37,37 +42,50 @@ BUILDENV_IMAGE_SET += cfsbuildenv-linux
 BUILDENV_IMAGE_SET += cfsbuildenv-mcdc
 BUILDENV_IMAGE_SET += cfsbuildenv-rtems5
 BUILDENV_IMAGE_SET += cfsbuildenv-rtems6
-# BUILDENV_IMAGE_SET += cfsbuildenv-yocto
 BUILDENV_IMAGE_SET += cfsbuildenv-arm-linux
 BUILDENV_IMAGE_SET += cfsbuildenv-gaisler-sparc-rcc
 BUILDENV_IMAGE_SET += cfsbuildenv-ubuntu22
 BUILDENV_IMAGE_SET += cfsbuildenv-el9
 BUILDENV_IMAGE_SET += cfsbuildenv-el8
+BUILDENV_IMAGE_SET += cfsbuildenv-yocto
 ALL_IMAGE_SET += $(BUILDENV_IMAGE_SET)
 
-# The rest of the images each need a custom rule with custom deps
-# ALL_IMAGE_SET += yocto-sources
-# ALL_IMAGE_SET += yocto-compile-qemuriscv64
-# ALL_IMAGE_SET += yocto-image-qemuriscv64
-# ALL_IMAGE_SET += yocto-sdk-qemuriscv64
-# ALL_IMAGE_SET += yocto-compile-qemumips
-# ALL_IMAGE_SET += yocto-image-qemumips
-# ALL_IMAGE_SET += yocto-sdk-qemumips
-ALL_IMAGE_SET += rtems5-tools
-ALL_IMAGE_SET += rtems6-tools
-ALL_IMAGE_SET += rtems5-rtos
-ALL_IMAGE_SET += rtems6-rtos
+# Images related to the yocto build
+# This is a large build and is disk and memory intensive
+# This may be excluded from the daily builds for this reason
+YOCTO_IMAGE_SET += yocto-sources
+YOCTO_IMAGE_SET += yocto-compile-qemuriscv64
+YOCTO_IMAGE_SET += yocto-image-qemuriscv64
+YOCTO_IMAGE_SET += yocto-sdk-qemuriscv64
+YOCTO_IMAGE_SET += yocto-compile-qemumips
+YOCTO_IMAGE_SET += yocto-image-qemumips
+YOCTO_IMAGE_SET += yocto-sdk-qemumips
+ALL_IMAGE_SET += $(YOCTO_IMAGE_SET)
+
+# Images related to rtems build
+RTEMS_IMAGE_SET += rtems5-tools
+RTEMS_IMAGE_SET += rtems6-tools
+RTEMS_IMAGE_SET += rtems5-rtos
+RTEMS_IMAGE_SET += rtems6-rtos
+ALL_IMAGE_SET += $(RTEMS_IMAGE_SET)
 
 ALL_BUILD_TARGETS      := $(addsuffix .build,$(ALL_IMAGE_SET))
 ALL_IMAGE_TARGETS      := $(addsuffix .image,$(ALL_IMAGE_SET))
 ALL_PUSH_TARGETS       := $(addsuffix .push,$(ALL_IMAGE_SET))
 ALL_PULL_TARGETS       := $(addsuffix .pull,$(ALL_IMAGE_SET))
 
+# The pipeline targets exclude yocto
+ALL_PIPELINE_SET = $(BASIC_IMAGE_SET) $(BUILDENV_IMAGE_SET) $(YOCTO_IMAGE_SET) $(RTEMS_IMAGE_SET)
+
 $(ALL_BUILD_TARGETS) $(ALL_IMAGE_TARGETS) $(ALL_PUSH_TARGETS) $(ALL_PULL_TARGETS): IMAGE_NAME = $(basename $(@))
 
 all: $(ALL_IMAGE_TARGETS)
 push: $(ALL_PUSH_TARGETS)
 pull: $(ALL_PULL_TARGETS)
+
+all-pipeline: $(addsuffix .image,$(ALL_PIPELINE_SET))
+push-pipeline: $(addsuffix .push,$(ALL_PIPELINE_SET))
+pull-pipeline: $(addsuffix .pull,$(ALL_PIPELINE_SET))
 
 check:
 	env
@@ -78,124 +96,126 @@ cfsbuildenv-rtems5.image: rtems5-rtos.image
 cfsbuildenv-rtems6.image: rtems6-rtos.image
 cfsbuildenv-arm-linux.image: arm-linux-sdk.image cfsbuildenv-linux.image
 cfsbuildenv-gaisler-sparc-rcc.image: gaisler-sparc-rcc-sdk.image cfsbuildenv-linux.image
-yocto-sdk.image: cfsbuildenv-linux.image
+cfsbuildenv-yocto.image: yocto-sdk-qemuriscv64.image yocto-sdk-qemumips.image
 
 
 %.build:
-	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_IMAGE_NAME) -f $(subst rtems5-,rtems-,$(subst rtems6-,rtems-,$(IMAGE_NAME)))/Dockerfile .
+	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_LOCAL_NAME) -f $(subst rtems5-,rtems-,$(subst rtems6-,rtems-,$(IMAGE_NAME)))/Dockerfile .
 
 # RTEMS 5 Tools
 rtems5-tools.build:
-	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_IMAGE_NAME) \
+	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_LOCAL_NAME) \
 		--build-arg RTEMS_VER=5 \
 		-f rtems-tools/Dockerfile .
 
 # RTEMS 6 Tools
 rtems6-tools.build:
-	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_IMAGE_NAME) \
+	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_LOCAL_NAME) \
 		--build-arg RTEMS_VER=6 \
 		-f rtems-tools/Dockerfile .
 
 # RTEMS 5 RTOS
 rtems5-rtos.build:
-	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_IMAGE_NAME) \
-		--build-arg TOOLS_IMAGE=rtems5-tools:$(LOCAL_TAG) \
+	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_LOCAL_NAME) \
+		--build-arg TOOLS_IMAGE=$(TGT_REPO)/rtems5-tools:$(LOCAL_TAG) \
 		--build-arg RTEMS_VER=5 \
 		-f rtems-rtos/Dockerfile .
 
 # RTEMS 6 RTOS
 rtems6-rtos.build:
-	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_IMAGE_NAME) \
-		--build-arg TOOLS_IMAGE=rtems6-tools:$(LOCAL_TAG) \
+	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_LOCAL_NAME) \
+		--build-arg TOOLS_IMAGE=$(TGT_REPO)/rtems6-tools:$(LOCAL_TAG) \
 		--build-arg RTEMS_VER=6 \
 		-f rtems-rtos/Dockerfile .
 
 # cFS Build Environment - RTEMS 5
 cfsbuildenv-rtems5.build:
-	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_IMAGE_NAME) \
-		--build-arg RTEMS_RTOS_IMAGE=rtems5-rtos:$(LOCAL_TAG) \
+	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_LOCAL_NAME) \
+		--build-arg RTEMS_RTOS_IMAGE=$(TGT_REPO)/rtems5-rtos:$(LOCAL_TAG) \
 		-f cfsbuildenv-rtems/Dockerfile .
 
 # cFS Build Environment - RTEMS 6
 cfsbuildenv-rtems6.build:
-	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_IMAGE_NAME) \
-		--build-arg RTEMS_RTOS_IMAGE=rtems6-rtos:$(LOCAL_TAG) \
+	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_LOCAL_NAME) \
+		--build-arg RTEMS_RTOS_IMAGE=$(TGT_REPO)/rtems6-rtos:$(LOCAL_TAG) \
 		-f cfsbuildenv-rtems/Dockerfile .
 
 cfsbuildenv-doxygen.build:
-	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_IMAGE_NAME) -f cfsbuildenv-doxygen/Dockerfile .
+	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_LOCAL_NAME) -f cfsbuildenv-doxygen/Dockerfile .
 
 cfsbuildenv-mcdc.build:
-	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_IMAGE_NAME) -f cfsbuildenv-mcdc/Dockerfile .
+	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_LOCAL_NAME) -f cfsbuildenv-mcdc/Dockerfile .
 
 cfsbuildenv-linux.build cfsbuildenv-ubuntu22.build:
-	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_IMAGE_NAME) -f cfsbuildenv-dpkg/Dockerfile .
+	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_LOCAL_NAME) -f cfsbuildenv-dpkg/Dockerfile .
 
 cfsbuildenv-el8.build cfsbuildenv-el9.build:
-	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_IMAGE_NAME) -f cfsbuildenv-rpm/Dockerfile .
+	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_LOCAL_NAME) -f cfsbuildenv-rpm/Dockerfile .
 
 yocto-sources.build: cfsbuildenv-linux.image
 yocto-sources.build:
-	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_IMAGE_NAME) \
-		--build-arg BASE_IMAGE=cfsbuildenv-linux:$(LOCAL_TAG) \
+	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_LOCAL_NAME) \
+		--build-arg BASE_IMAGE=$(TGT_REPO)/cfsbuildenv-linux:$(LOCAL_TAG) \
 		-f yocto-sources/Dockerfile .
 
 yocto-compile-qemuriscv64.build: yocto-sources.image
 yocto-compile-qemumips.build: yocto-sources.image
 yocto-compile-%.build:
-	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_IMAGE_NAME) \
-		--build-arg BASE_IMAGE=yocto-sources:$(LOCAL_TAG) \
+	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_LOCAL_NAME) \
+		--build-arg BASE_IMAGE=$(TGT_REPO)/yocto-sources:$(LOCAL_TAG) \
 		--build-arg MACHINE=$(*) \
 		-f yocto-compile/Dockerfile .
 
 yocto-image-qemuriscv64.build: yocto-compile-qemuriscv64.image
 yocto-image-qemumips.build: yocto-compile-qemumips.image
 yocto-image-%.build:
-	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_IMAGE_NAME) \
-		--build-arg BASE_IMAGE=yocto-compile-$(*):$(LOCAL_TAG) \
+	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_LOCAL_NAME) \
+		--build-arg BASE_IMAGE=$(TGT_REPO)/yocto-compile-$(*):$(LOCAL_TAG) \
 		--build-arg MACHINE=$(*) \
 		-f yocto-image/Dockerfile .
 
 yocto-sdk-qemuriscv64.build: yocto-compile-qemuriscv64.image
 yocto-sdk-qemumips.build: yocto-compile-qemumips.image
 yocto-sdk-%.build:
-	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_IMAGE_NAME) \
-		--build-arg BASE_IMAGE=yocto-compile-$(*):$(LOCAL_TAG) \
+	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_LOCAL_NAME) \
+		--build-arg BASE_IMAGE=$(TGT_REPO)/yocto-compile-$(*):$(LOCAL_TAG) \
 		--build-arg MACHINE=$(*) \
 		-f yocto-sdk/Dockerfile .
 
 cfsbuildenv-yocto.build:
-	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_IMAGE_NAME) \
-		--build-arg YOCTO_SDK_IMAGE=yocto-sdk:$(LOCAL_TAG) \
+	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_LOCAL_NAME) \
+		--build-arg YOCTO_SDK_IMAGE_RISCV=$(TGT_REPO)/yocto-sdk-qemuriscv64:$(LOCAL_TAG) \
+		--build-arg YOCTO_SDK_IMAGE_MIPS=$(TGT_REPO)/yocto-sdk-qemumips:$(LOCAL_TAG) \
 		-f cfsbuildenv-yocto/Dockerfile .
 
 cfsbuildenv-arm-linux.build:
-	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_IMAGE_NAME) \
-		--build-arg BASE_IMAGE=cfsbuildenv-linux:$(LOCAL_TAG) \
-		--build-arg SDK_IMAGE=arm-linux-sdk:$(LOCAL_TAG) \
+	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_LOCAL_NAME) \
+		--build-arg BASE_IMAGE=$(TGT_REPO)/cfsbuildenv-linux:$(LOCAL_TAG) \
+		--build-arg SDK_IMAGE=$(TGT_REPO)/arm-linux-sdk:$(LOCAL_TAG) \
 		-f cfsbuildenv-arm-linux/Dockerfile .
 
 cfsbuildenv-gaisler-sparc-rcc.build:
-	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_IMAGE_NAME) \
-		--build-arg BASE_IMAGE=cfsbuildenv-linux:$(LOCAL_TAG) \
-		--build-arg SDK_IMAGE=gaisler-sparc-rcc-sdk:$(LOCAL_TAG) \
+	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_LOCAL_NAME) \
+		--build-arg BASE_IMAGE=$(TGT_REPO)/cfsbuildenv-linux:$(LOCAL_TAG) \
+		--build-arg SDK_IMAGE=$(TGT_REPO)/gaisler-sparc-rcc-sdk:$(LOCAL_TAG) \
 		-f cfsbuildenv-gaisler-sparc-rcc/Dockerfile .
 
 cfsexec-linux.build cfsexec-ubuntu22.build:
-	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_IMAGE_NAME) -f cfsexec-dpkg/Dockerfile .
+	docker build $(EXTRA_BUILDARGS) -t $(QUALIFIED_LOCAL_NAME) -f cfsexec-dpkg/Dockerfile .
 
 %.push:
-	docker tag $(QUALIFIED_IMAGE_NAME) $(TGT_REPO)/$(QUALIFIED_IMAGE_NAME)
-	docker push $(TGT_REPO)/$(QUALIFIED_IMAGE_NAME)
+	docker push $(QUALIFIED_LOCAL_NAME)
+	docker tag $(QUALIFIED_LOCAL_NAME) $(QUALIFIED_REPO_NAME)
+	docker push $(QUALIFIED_REPO_NAME)
 
 %.pull:
-	docker pull $(TGT_REPO)/$(IMAGE_NAME):$(REPO_TAG)
+	docker pull $(QUALIFIED_REPO_NAME)
 
 # the idea here is to check if the image was already built, and if so, just
 # use the already-built image from the container repo.  This is done by commit hash.
 %.image:
-	docker pull $(TGT_REPO)/$(QUALIFIED_IMAGE_NAME) || /bin/true
-	docker inspect $(QUALIFIED_IMAGE_NAME) > /dev/null || $(BUILD_DEP_CMD)
+	docker pull $(QUALIFIED_LOCAL_NAME) || /bin/true
+	$(BUILD_DEP_CMD)
 
 # The following is a list of images that rely on a base
 # image that uses the Debian-style package management via

--- a/cfsbuildenv-yocto/Dockerfile
+++ b/cfsbuildenv-yocto/Dockerfile
@@ -3,10 +3,12 @@
 # for an embedded Linux target using Yocto
 #########################################################
 
-ARG YOCTO_SDK_IMAGE=yocto-sdk
+ARG YOCTO_SDK_IMAGE_RISCV=yocto-sdk-qemuriscv64
+ARG YOCTO_SDK_IMAGE_MIPS=yocto-sdk-qemumips
 ARG BASE_IMAGE=debian:trixie
 
-FROM ${YOCTO_SDK_IMAGE} AS yocto-sdk
+FROM ${YOCTO_SDK_IMAGE_RISCV} AS yocto-sdk-riscv64
+FROM ${YOCTO_SDK_IMAGE_MIPS} AS yocto-sdk-mips
 FROM ${BASE_IMAGE} AS cfsbuildenv-yocto
 
 ARG EXTRA_PKGS=""
@@ -20,12 +22,11 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
         ${EXTRA_PKGS} && \
     rm -rf /var/cache/apt
 
+RUN mkdir -p /opt 
+
 # Bring the SDK entirely from the yocto-sdk image,
-COPY --from=yocto-sdk /opt /opt
+COPY --from=yocto-sdk-riscv64 /opt /opt
+COPY --from=yocto-sdk-mips /opt /opt
 
-# Create a non-root user to do the build, but grant sudo to permit adding dependencies if needed
-RUN useradd -m -c "Docker user" -U -G sudo docker && \
-    echo "%sudo   ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers
+RUN for ver in /opt/poky/*; do ln -sv $(basename $ver) ${ver%.*}; done
 
-USER docker
-WORKDIR /home/docker

--- a/yocto-sources/Dockerfile
+++ b/yocto-sources/Dockerfile
@@ -7,6 +7,14 @@ FROM ${BASE_IMAGE} AS yocto-sources
 
 ARG YOCTO_BRANCH=scarthgap
 
+# Create a non-root user to do the build, but grant sudo to permit adding dependencies if needed
+RUN useradd -m -c "Docker user" -U -G sudo docker && \
+    echo "%sudo   ALL=(ALL:ALL) NOPASSWD:ALL" > /etc/sudoers
+
+USER docker
+WORKDIR /home/docker
+ENV HOME=/home/docker
+
 COPY yocto-sources/meta-cfecfs meta-cfecfs
 RUN git clone https://git.openembedded.org/meta-openembedded -b ${YOCTO_BRANCH} --depth 1
 RUN git clone https://git.yoctoproject.org/poky -b ${YOCTO_BRANCH} --depth 1
@@ -16,7 +24,6 @@ RUN sudo apt-get update && \
 RUN echo 'en_US.UTF-8 UTF-8' | sudo tee /etc/locale.gen && sudo locale-gen
 
 # These environment vars need to be set for bitbake to work
-ENV HOME=/home/docker
 ENV BUILDDIR="${HOME}/build-cfs"
 ENV OE_ADDED_PATHS="${HOME}/poky/scripts:${HOME}/poky/bitbake/bin:"
 ENV BB_ENV_PASSTHROUGH_ADDITIONS="ALL_PROXY BBPATH_EXTRA BB_LOGCONFIG BB_NO_NETWORK BB_NUMBER_THREADS BB_SETSCENE_ENFORCE BB_SRCREV_POLICY DISTRO FTPS_PROXY FTP_PROXY GIT_PROXY_COMMAND HTTPS_PROXY HTTP_PROXY MACHINE NO_PROXY PARALLEL_MAKE SCREENDIR SDKMACHINE SOCKS5_PASSWD SOCKS5_USER SSH_AGENT_PID SSH_AUTH_SOCK STAMPS_DIR TCLIBC TCMODE all_proxy ftp_proxy ftps_proxy http_proxy https_proxy no_proxy"


### PR DESCRIPTION
Re-enables the yocto targets, but adds a new makefile target for the pipeline builds that excludes these, because they are costly to build.

The yocto targets can be manually built outside of the workflow and pushed.